### PR TITLE
Link to https://travis-ci.org/rubytaiwan/rubytw-reboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ruby.tw Reboot
 
-[![Build Status](https://travis-ci.org/travis-ci/travis-api.svg?branch=master)](https://travis-ci.org/travis-ci/travis-api.svg)
+[![Build Status](https://travis-ci.org/rubytaiwan/rubytw-reboot.svg?branch=master)](https://travis-ci.org/rubytaiwan/rubytw-reboot)
 
 A site for Taiwan Ruby Community!
 


### PR DESCRIPTION
The badge url is wrong. Should link to this repository’s page on https://travis-ci.org.
