### PR TITLE
Add slackin badge [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ruby.tw Reboot
 
-[![Build Status](https://travis-ci.org/rubytaiwan/rubytw-reboot.svg?branch=master)](https://travis-ci.org/rubytaiwan/rubytw-reboot) [![Code Climate](https://codeclimate.com/github/rubytaiwan/rubytw-reboot/badges/gpa.svg)](https://codeclimate.com/github/rubytaiwan/rubytw-reboot)
+[![Build Status](https://travis-ci.org/rubytaiwan/rubytw-reboot.svg?branch=master)](https://travis-ci.org/rubytaiwan/rubytw-reboot) [![Code Climate](https://codeclimate.com/github/rubytaiwan/rubytw-reboot/badges/gpa.svg)](https://codeclimate.com/github/rubytaiwan/rubytw-reboot) [![Slack](https://rubytaiwan-slackin.herokuapp.com/badge.svg)](https://rubytaiwan-slackin.herokuapp.com)
 
 https://rubytw-production.herokuapp.com/
 


### PR DESCRIPTION
Set up and integrate [slackin](https://github.com/rauchg/slackin):

[![Slack](https://rubytaiwan-slackin.herokuapp.com/badge.svg)](https://rubytaiwan-slackin.herokuapp.com)

Another way to invite yourself to join [our Slack](https://rubytaiwan.slack.com). See [rendered README.md](https://github.com/rubytaiwan/rubytw-reboot/blob/af7895a05114e6abff26a4be56f569a2d5740361/README.md).
